### PR TITLE
fix: 修复无法代理 http://localhost:1987/proxy/?https://xxxx的问题

### DIFF
--- a/server.js
+++ b/server.js
@@ -174,7 +174,7 @@
     var remoteUrl = getRemoteUrlFromParam(req);
     if (!remoteUrl) {
       // look for request like http://localhost:8080/proxy/?http%3A%2F%2Fexample.com%2Ffile%3Fquery%3D1
-      remoteUrl = Object.keys(req.query)[0];
+      remoteUrl = req.originalUrl.split('?').slice(1).join('?')
       if (remoteUrl) {
         remoteUrl = url.parse(remoteUrl);
       }


### PR DESCRIPTION

mars2d的mapoption配置代理：
```
basemaps: [
      {
        name: '高德地图',
        type: 'gaode',
        layer: 'time',
        show: true,
        proxy: 'http://localhost:1987/proxy/',
      }
]
```
请求的是：![image](https://github.com/user-attachments/assets/c7f206f1-3db7-4873-8fa1-07dc76091fe6)，
`http://localhost:1987/proxy/?https://tm.amap.com/trafficengine/mapabc/traffictile?v=1.0&t=1&x=6765&y=3331&z=13&&t=1737362665846`

原来的写法:
```
remoteUrl = Object.keys(req.query)[0]
```

会漏掉后面的参数代理到：`https://tm.amap.com/trafficengine/mapabc/traffictile?v=1.0`

因此修改为：
```
remoteUrl = req.originalUrl.split('?').slice(1).join('?')
```